### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/oxibus/rrdbc/compare/v0.1.0...v0.2.0) - 2025-10-03
+
+### Added
+
+- change lincese from mit to mit and apache2
+- add tool gbk2utf8 utf82gbk
+- update signal multiplexer
+- add tool dbcfmt
+- add tool json to dbc
+- add parser dbc file
+- add tool toutf8
+- add encoding
+- update char string
+- update char string
+- update char string
+- update char string
+- update char string
+- update char string
+- update char string
+- update char string
+- add char string
+- update char_string and value description
+
+### Other
+
+- update README with new project name and add badges ([#10](https://github.com/oxibus/rrdbc/pull/10))
+- gramar and spelink ([#11](https://github.com/oxibus/rrdbc/pull/11))
+- fix clippy lints ([#9](https://github.com/oxibus/rrdbc/pull/9))
+- reformat code ([#8](https://github.com/oxibus/rrdbc/pull/8))
+- fix CI ([#6](https://github.com/oxibus/rrdbc/pull/6))
+- add CI and justfile recipes ([#4](https://github.com/oxibus/rrdbc/pull/4))
+- re-license code as MIT OR Apache2
+- upgrade to nom 8, thiserror 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rrdbc"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["MDGSF"]
 edition = "2021"
 description = "dbc parser"


### PR DESCRIPTION



## 🤖 New release

* `rrdbc`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `rrdbc` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_missing.ron

Failed in:
  enum rrdbc::ast::signal::DbcSignalMultiplexer, previously in file /tmp/.tmpH2YsuQ/rrdbc/src/ast/signal.rs:25

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/function_missing.ron

Failed in:
  function rrdbc::file::try_read_file_content_with_window_1252, previously in file /tmp/.tmpH2YsuQ/rrdbc/src/file.rs:26
  function rrdbc::ast::common_parsers::escape_code, previously in file /tmp/.tmpH2YsuQ/rrdbc/src/ast/common_parsers.rs:58
  function rrdbc::ast::common_parsers::char_string, previously in file /tmp/.tmpH2YsuQ/rrdbc/src/ast/common_parsers.rs:88
  function rrdbc::ast::common_parsers::printable_character, previously in file /tmp/.tmpH2YsuQ/rrdbc/src/ast/common_parsers.rs:47
  function rrdbc::ast::common_parsers::string_body, previously in file /tmp/.tmpH2YsuQ/rrdbc/src/ast/common_parsers.rs:75
  function rrdbc::file::try_read_file_content_with_gbk, previously in file /tmp/.tmpH2YsuQ/rrdbc/src/file.rs:12
  function rrdbc::ast::common_parsers::nonescaped_string, previously in file /tmp/.tmpH2YsuQ/rrdbc/src/ast/common_parsers.rs:54
  function rrdbc::file::try_read_file_content_with_utf8, previously in file /tmp/.tmpH2YsuQ/rrdbc/src/file.rs:7
  function rrdbc::ast::common_parsers::string_literal, previously in file /tmp/.tmpH2YsuQ/rrdbc/src/ast/common_parsers.rs:79

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rrdbc::file::read_file_content now takes 2 parameters instead of 1, in /tmp/.tmpeQZ1jQ/rrdbc/src/file.rs:9

--- failure function_requires_different_generic_type_params: function now requires a different number of generic type parameters ---

Description:
A function now requires a different number of generic type parameters than it used to. Uses of this function that supplied the previous number of generic types (e.g. via turbofish syntax) will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/function_requires_different_generic_type_params.ron

Failed in:
  function multispacey (4 -> 3 generic types) in /tmp/.tmpeQZ1jQ/rrdbc/src/ast/common_parsers.rs:24
  function spacey (4 -> 3 generic types) in /tmp/.tmpeQZ1jQ/rrdbc/src/ast/common_parsers.rs:13
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/oxibus/rrdbc/compare/v0.1.0...v0.2.0) - 2025-10-03

### Added

- change lincese from mit to mit and apache2
- add tool gbk2utf8 utf82gbk
- update signal multiplexer
- add tool dbcfmt
- add tool json to dbc
- add parser dbc file
- add tool toutf8
- add encoding
- update char string
- update char string
- update char string
- update char string
- update char string
- update char string
- update char string
- update char string
- add char string
- update char_string and value description

### Other

- update README with new project name and add badges ([#10](https://github.com/oxibus/rrdbc/pull/10))
- gramar and spelink ([#11](https://github.com/oxibus/rrdbc/pull/11))
- fix clippy lints ([#9](https://github.com/oxibus/rrdbc/pull/9))
- reformat code ([#8](https://github.com/oxibus/rrdbc/pull/8))
- fix CI ([#6](https://github.com/oxibus/rrdbc/pull/6))
- add CI and justfile recipes ([#4](https://github.com/oxibus/rrdbc/pull/4))
- re-license code as MIT OR Apache2
- upgrade to nom 8, thiserror 2
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).