### PR TITLE
chore: reformat code

### DIFF
--- a/src/ast/attribute.rs
+++ b/src/ast/attribute.rs
@@ -1,9 +1,9 @@
-use super::common_parsers::*;
-use super::error::DbcParseError;
 use nom::bytes::complete::tag;
 use nom::sequence::delimited;
-use nom::IResult;
-use nom::Parser;
+use nom::{IResult, Parser};
+
+use super::common_parsers::*;
+use super::error::DbcParseError;
 
 pub fn parser_attribute_name(input: &str) -> IResult<&str, &str, DbcParseError> {
     delimited(tag("\""), dbc_identifier, tag("\"")).parse(input)

--- a/src/ast/attribute_default.rs
+++ b/src/ast/attribute_default.rs
@@ -1,15 +1,15 @@
-use super::attribute::parser_attribute_name;
-use super::char_string::parser_char_string;
-use super::char_string::CharString;
-use super::common_parsers::*;
-use super::error::DbcParseError;
+use std::fmt;
+
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
-use nom::IResult;
-use nom::Parser;
+use nom::{IResult, Parser};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+
+use super::attribute::parser_attribute_name;
+use super::char_string::{parser_char_string, CharString};
+use super::common_parsers::*;
+use super::error::DbcParseError;
 
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub enum AttributeValue {

--- a/src/ast/attribute_definition.rs
+++ b/src/ast/attribute_definition.rs
@@ -1,16 +1,16 @@
-use super::attribute::parser_attribute_name;
-use super::char_string::parser_char_string;
-use super::char_string::CharString;
-use super::common_parsers::*;
-use super::error::DbcParseError;
+use std::fmt;
+
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
 use nom::multi::separated_list0;
-use nom::IResult;
-use nom::Parser;
+use nom::{IResult, Parser};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+
+use super::attribute::parser_attribute_name;
+use super::char_string::{parser_char_string, CharString};
+use super::common_parsers::*;
+use super::error::DbcParseError;
 
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct AttributeIntegerValueType {

--- a/src/ast/attribute_value.rs
+++ b/src/ast/attribute_value.rs
@@ -1,15 +1,15 @@
-use super::attribute::parser_attribute_name;
-use super::attribute_default::parser_attribute_value;
-use super::attribute_default::AttributeValue;
-use super::common_parsers::*;
-use super::error::DbcParseError;
+use std::fmt;
+
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
-use nom::IResult;
-use nom::Parser;
+use nom::{IResult, Parser};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+
+use super::attribute::parser_attribute_name;
+use super::attribute_default::{parser_attribute_value, AttributeValue};
+use super::common_parsers::*;
+use super::error::DbcParseError;
 
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkAttributeValue {

--- a/src/ast/bit_timing.rs
+++ b/src/ast/bit_timing.rs
@@ -1,15 +1,14 @@
+use std::fmt;
+
+use nom::bytes::complete::tag;
+use nom::character::complete::{line_ending, u64};
+use nom::combinator::{map, opt};
+use nom::multi::many0;
+use nom::{IResult, Parser};
+use serde::{Deserialize, Serialize};
+
 use super::common_parsers::*;
 use super::error::DbcParseError;
-use nom::bytes::complete::tag;
-use nom::character::complete::line_ending;
-use nom::character::complete::u64;
-use nom::combinator::map;
-use nom::combinator::opt;
-use nom::multi::many0;
-use nom::IResult;
-use nom::Parser;
-use serde::{Deserialize, Serialize};
-use std::fmt;
 
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct BitTimingValue {

--- a/src/ast/char_string.rs
+++ b/src/ast/char_string.rs
@@ -1,18 +1,15 @@
-use super::error::DbcParseError;
+use std::fmt;
+
 use nom::branch::alt;
 use nom::bytes::complete::tag;
-use nom::character::complete::anychar;
-use nom::character::complete::none_of;
-use nom::character::complete::satisfy;
-use nom::combinator::map;
-use nom::combinator::recognize;
+use nom::character::complete::{anychar, none_of, satisfy};
+use nom::combinator::{map, recognize};
 use nom::multi::many0;
-use nom::sequence::delimited;
-use nom::sequence::pair;
-use nom::IResult;
-use nom::Parser;
+use nom::sequence::{delimited, pair};
+use nom::{IResult, Parser};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+
+use super::error::DbcParseError;
 
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct CharString(pub String);

--- a/src/ast/comment.rs
+++ b/src/ast/comment.rs
@@ -1,14 +1,14 @@
-use super::char_string::parser_char_string;
-use super::char_string::CharString;
-use super::common_parsers::*;
-use super::error::DbcParseError;
+use std::fmt;
+
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
-use nom::IResult;
-use nom::Parser;
+use nom::{IResult, Parser};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+
+use super::char_string::{parser_char_string, CharString};
+use super::common_parsers::*;
+use super::error::DbcParseError;
 
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkComment {

--- a/src/ast/common_parsers.rs
+++ b/src/ast/common_parsers.rs
@@ -1,27 +1,14 @@
-use super::error::DbcParseError;
 use nom::branch::alt;
-use nom::bytes::complete::tag;
-use nom::bytes::complete::tag_no_case;
-use nom::bytes::complete::take_while1;
-use nom::character::complete::alphanumeric1;
-use nom::character::complete::digit0;
-use nom::character::complete::digit1;
-use nom::character::complete::i32;
-use nom::character::complete::multispace0;
-use nom::character::complete::one_of;
-use nom::character::complete::satisfy;
-use nom::character::complete::space0;
-use nom::character::complete::u32;
-use nom::combinator::map;
-use nom::combinator::not;
-use nom::combinator::opt;
-use nom::combinator::recognize;
+use nom::bytes::complete::{tag, tag_no_case, take_while1};
+use nom::character::complete::{
+    alphanumeric1, digit0, digit1, i32, multispace0, one_of, satisfy, space0, u32,
+};
+use nom::combinator::{map, not, opt, recognize};
 use nom::multi::many0;
-use nom::sequence::delimited;
-use nom::sequence::pair;
-use nom::AsChar;
-use nom::IResult;
-use nom::Parser;
+use nom::sequence::{delimited, pair};
+use nom::{AsChar, IResult, Parser};
+
+use super::error::DbcParseError;
 
 pub fn spacey<I, O, E>(
     f: impl Parser<I, Output = O, Error = E>,

--- a/src/ast/env_var.rs
+++ b/src/ast/env_var.rs
@@ -1,19 +1,16 @@
-use super::char_string::parser_char_string;
-use super::char_string::CharString;
+use std::fmt;
+
+use nom::bytes::complete::tag;
+use nom::character::complete::{hex_digit1, line_ending, u32};
+use nom::combinator::map;
+use nom::multi::{many0, separated_list0};
+use nom::sequence::pair;
+use nom::{IResult, Parser};
+use serde::{Deserialize, Serialize};
+
+use super::char_string::{parser_char_string, CharString};
 use super::common_parsers::*;
 use super::error::DbcParseError;
-use nom::bytes::complete::tag;
-use nom::character::complete::hex_digit1;
-use nom::character::complete::line_ending;
-use nom::character::complete::u32;
-use nom::combinator::map;
-use nom::multi::many0;
-use nom::multi::separated_list0;
-use nom::sequence::pair;
-use nom::IResult;
-use nom::Parser;
-use serde::{Deserialize, Serialize};
-use std::fmt;
 
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub enum EnvVarType {

--- a/src/ast/env_var_data.rs
+++ b/src/ast/env_var_data.rs
@@ -1,14 +1,14 @@
-use super::common_parsers::*;
-use super::error::DbcParseError;
+use std::fmt;
+
 use nom::bytes::complete::tag;
-use nom::character::complete::line_ending;
-use nom::character::complete::u32;
+use nom::character::complete::{line_ending, u32};
 use nom::combinator::map;
 use nom::multi::many0;
-use nom::IResult;
-use nom::Parser;
+use nom::{IResult, Parser};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+
+use super::common_parsers::*;
+use super::error::DbcParseError;
 
 /// Environment variables data section
 ///

--- a/src/ast/env_var_value_descriptions.rs
+++ b/src/ast/env_var_value_descriptions.rs
@@ -1,15 +1,15 @@
-use super::common_parsers::*;
-use super::error::DbcParseError;
-use super::value_descriptions::parser_value_descriptions;
-use super::value_descriptions::ValueDescriptions;
+use std::fmt;
+
 use nom::bytes::complete::tag;
 use nom::character::complete::line_ending;
 use nom::combinator::map;
 use nom::multi::many0;
-use nom::IResult;
-use nom::Parser;
+use nom::{IResult, Parser};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+
+use super::common_parsers::*;
+use super::error::DbcParseError;
+use super::value_descriptions::{parser_value_descriptions, ValueDescriptions};
 
 /// ```text
 /// VAL_ env_var_name [value_descriptions];

--- a/src/ast/error.rs
+++ b/src/ast/error.rs
@@ -1,5 +1,4 @@
-use nom::error::ContextError;
-use nom::error::{ErrorKind, ParseError};
+use nom::error::{ContextError, ErrorKind, ParseError};
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum DbcParseError {

--- a/src/ast/message.rs
+++ b/src/ast/message.rs
@@ -1,16 +1,16 @@
-use super::common_parsers::*;
-use super::error::DbcParseError;
-use super::signal::parser_signal;
-use super::signal::Signal;
+use std::fmt;
+
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::line_ending;
 use nom::combinator::map;
 use nom::multi::many0;
-use nom::IResult;
-use nom::Parser;
+use nom::{IResult, Parser};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+
+use super::common_parsers::*;
+use super::error::DbcParseError;
+use super::signal::{parser_signal, Signal};
 
 /// Message definition.
 /// Format: `BO_ <CAN-ID> <MessageName>: <MessageSize> <SendingNode>`

--- a/src/ast/network_ast.rs
+++ b/src/ast/network_ast.rs
@@ -1,38 +1,28 @@
-use super::attribute_default::parser_attribute_default;
-use super::attribute_default::AttributeDefault;
-use super::attribute_definition::parser_attribute_definition;
-use super::attribute_definition::AttributeDefinition;
-use super::attribute_value::parser_object_attribute_value;
-use super::attribute_value::ObjectAttributeValue;
-use super::bit_timing::parser_bit_timing;
-use super::bit_timing::BitTiming;
-use super::comment::parser_comment;
-use super::comment::Comment;
+use std::fmt;
+
+use nom::combinator::{all_consuming, map};
+use nom::multi::many0;
+use nom::{IResult, Parser};
+use serde::{Deserialize, Serialize};
+
+use super::attribute_default::{parser_attribute_default, AttributeDefault};
+use super::attribute_definition::{parser_attribute_definition, AttributeDefinition};
+use super::attribute_value::{parser_object_attribute_value, ObjectAttributeValue};
+use super::bit_timing::{parser_bit_timing, BitTiming};
+use super::comment::{parser_comment, Comment};
 use super::common_parsers::*;
-use super::env_var::parser_env_var;
-use super::env_var::EnvironmentVariable;
-use super::env_var_data::parser_env_var_data;
-use super::env_var_data::EnvironmentVariableData;
-use super::env_var_value_descriptions::parser_env_var_value_descriptions;
-use super::env_var_value_descriptions::EnvironmentVariableValueDescriptions;
+use super::env_var::{parser_env_var, EnvironmentVariable};
+use super::env_var_data::{parser_env_var_data, EnvironmentVariableData};
+use super::env_var_value_descriptions::{
+    parser_env_var_value_descriptions, EnvironmentVariableValueDescriptions,
+};
 use super::error::DbcParseError;
 use super::message::*;
-use super::new_symbols::parser_new_symbols;
-use super::new_symbols::NewSymbols;
-use super::nodes::parser_nodes;
-use super::nodes::Nodes;
-use super::signal_value_descriptions::parser_signal_value_descriptions;
-use super::signal_value_descriptions::SignalValueDescriptions;
+use super::new_symbols::{parser_new_symbols, NewSymbols};
+use super::nodes::{parser_nodes, Nodes};
+use super::signal_value_descriptions::{parser_signal_value_descriptions, SignalValueDescriptions};
 use super::value_tables::*;
-use super::version::parser_version;
-use super::version::Version;
-use nom::combinator::all_consuming;
-use nom::combinator::map;
-use nom::multi::many0;
-use nom::IResult;
-use nom::Parser;
-use serde::{Deserialize, Serialize};
-use std::fmt;
+use super::version::{parser_version, Version};
 
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkAst {
@@ -226,23 +216,16 @@ pub fn parse_dbc(input: &str) -> Result<NetworkAst, DbcParseError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::attribute_definition::AttributeEnumValueType;
-    use crate::ast::attribute_definition::AttributeFloatValueType;
-    use crate::ast::attribute_definition::AttributeHexValueType;
-    use crate::ast::attribute_definition::AttributeIntegerValueType;
-    use crate::ast::attribute_definition::AttributeStringValueType;
-    use crate::ast::attribute_definition::AttributeValueType;
-    use crate::ast::attribute_definition::ControlUnitEnvironmentVariableAttribute;
-    use crate::ast::attribute_definition::EnvironmentVariableAttribute;
-    use crate::ast::attribute_definition::MessageAttribute;
-    use crate::ast::attribute_definition::NetworkAttribute;
-    use crate::ast::attribute_definition::NodeAttribute;
-    use crate::ast::attribute_definition::SignalAttribute;
+    use crate::ast::attribute_definition::{
+        AttributeEnumValueType, AttributeFloatValueType, AttributeHexValueType,
+        AttributeIntegerValueType, AttributeStringValueType, AttributeValueType,
+        ControlUnitEnvironmentVariableAttribute, EnvironmentVariableAttribute, MessageAttribute,
+        NetworkAttribute, NodeAttribute, SignalAttribute,
+    };
     use crate::ast::char_string::CharString;
     use crate::ast::env_var::EnvVarType;
     use crate::ast::signal;
-    use crate::ast::value_descriptions::ValueDescriptionItem;
-    use crate::ast::value_descriptions::ValueDescriptions;
+    use crate::ast::value_descriptions::{ValueDescriptionItem, ValueDescriptions};
 
     #[test]
     fn test_dbc_01() {

--- a/src/ast/new_symbols.rs
+++ b/src/ast/new_symbols.rs
@@ -1,14 +1,14 @@
-use super::common_parsers::*;
-use super::error::DbcParseError;
+use std::fmt;
+
 use nom::bytes::complete::tag;
-use nom::character::complete::line_ending;
-use nom::character::complete::space0;
+use nom::character::complete::{line_ending, space0};
 use nom::combinator::map;
 use nom::multi::many0;
-use nom::IResult;
-use nom::Parser;
+use nom::{IResult, Parser};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+
+use super::common_parsers::*;
+use super::error::DbcParseError;
 
 /// New Symbols, Names used throughout the DBC file.
 ///

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -1,13 +1,14 @@
-use super::common_parsers::*;
-use super::error::DbcParseError;
+use std::fmt;
+
 use nom::bytes::complete::tag;
 use nom::character::complete::line_ending;
 use nom::combinator::map;
 use nom::multi::many0;
-use nom::IResult;
-use nom::Parser;
+use nom::{IResult, Parser};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+
+use super::common_parsers::*;
+use super::error::DbcParseError;
 
 /// List of all CAN-Nodes, seperated by whitespaces.
 ///

--- a/src/ast/signal.rs
+++ b/src/ast/signal.rs
@@ -1,21 +1,17 @@
-use super::char_string::parser_char_string;
-use super::char_string::CharString;
-use super::common_parsers::*;
-use super::error::DbcParseError;
+use std::fmt;
+
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::line_ending;
-use nom::combinator::map;
-use nom::combinator::opt;
-use nom::multi::many0;
-use nom::multi::separated_list0;
-use nom::sequence::delimited;
-use nom::sequence::pair;
-use nom::sequence::separated_pair;
-use nom::IResult;
-use nom::Parser;
+use nom::combinator::{map, opt};
+use nom::multi::{many0, separated_list0};
+use nom::sequence::{delimited, pair, separated_pair};
+use nom::{IResult, Parser};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+
+use super::char_string::{parser_char_string, CharString};
+use super::common_parsers::*;
+use super::error::DbcParseError;
 
 /// example:
 ///

--- a/src/ast/signal_value_descriptions.rs
+++ b/src/ast/signal_value_descriptions.rs
@@ -1,15 +1,15 @@
-use super::common_parsers::*;
-use super::error::DbcParseError;
-use super::value_descriptions::parser_value_descriptions;
-use super::value_descriptions::ValueDescriptions;
+use std::fmt;
+
 use nom::bytes::complete::tag;
 use nom::character::complete::line_ending;
 use nom::combinator::map;
 use nom::multi::many0;
-use nom::IResult;
-use nom::Parser;
+use nom::{IResult, Parser};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+
+use super::common_parsers::*;
+use super::error::DbcParseError;
+use super::value_descriptions::{parser_value_descriptions, ValueDescriptions};
 
 /// ```text
 /// VAL_ message_id signal_name [value_descriptions];

--- a/src/ast/value_descriptions.rs
+++ b/src/ast/value_descriptions.rs
@@ -1,14 +1,14 @@
-use super::char_string::parser_char_string;
-use super::char_string::CharString;
-use super::common_parsers::*;
-use super::error::DbcParseError;
+use std::fmt;
+
 use nom::character::complete::i64;
 use nom::combinator::map;
 use nom::multi::many0;
-use nom::IResult;
-use nom::Parser;
+use nom::{IResult, Parser};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+
+use super::char_string::{parser_char_string, CharString};
+use super::common_parsers::*;
+use super::error::DbcParseError;
 
 /// A value description defines a textual description for a single value. This value may
 /// either be a signal raw value transferred on the bus or the value of an environment

--- a/src/ast/value_tables.rs
+++ b/src/ast/value_tables.rs
@@ -1,16 +1,15 @@
-use super::common_parsers::*;
-use super::error::DbcParseError;
-use super::value_descriptions::parser_value_descriptions;
-use super::value_descriptions::ValueDescriptions;
+use std::fmt;
+
 use nom::bytes::complete::tag;
 use nom::character::complete::line_ending;
-use nom::combinator::map;
-use nom::combinator::opt;
+use nom::combinator::{map, opt};
 use nom::multi::many0;
-use nom::IResult;
-use nom::Parser;
+use nom::{IResult, Parser};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+
+use super::common_parsers::*;
+use super::error::DbcParseError;
+use super::value_descriptions::{parser_value_descriptions, ValueDescriptions};
 
 /// The value table section defines the global value tables. The value descriptions in
 /// value tables define value encodings for signal raw values. In commonly used DBC

--- a/src/ast/version.rs
+++ b/src/ast/version.rs
@@ -1,14 +1,14 @@
-use super::char_string::parser_char_string;
-use super::char_string::CharString;
-use super::common_parsers::*;
-use super::error::DbcParseError;
+use std::fmt;
+
 use nom::bytes::complete::tag;
 use nom::combinator::map;
 use nom::sequence::preceded;
-use nom::IResult;
-use nom::Parser;
+use nom::{IResult, Parser};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+
+use super::char_string::{parser_char_string, CharString};
+use super::common_parsers::*;
+use super::error::DbcParseError;
 
 /// Version identifier of the DBC file.
 ///

--- a/src/bin/dbc2json.rs
+++ b/src/bin/dbc2json.rs
@@ -1,6 +1,7 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 use rrdbc::file::parser_dbc_file;
-use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/src/bin/dbcfmt.rs
+++ b/src/bin/dbcfmt.rs
@@ -1,6 +1,7 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 use rrdbc::file::parser_dbc_file;
-use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/src/bin/gbk2utf8.rs
+++ b/src/bin/gbk2utf8.rs
@@ -1,8 +1,9 @@
-use anyhow::Result;
-use rrdbc::encoding::gbk_to_utf8;
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
+
+use anyhow::Result;
+use rrdbc::encoding::gbk_to_utf8;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/src/bin/json2dbc.rs
+++ b/src/bin/json2dbc.rs
@@ -1,6 +1,7 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 use rrdbc::ast::network_ast::NetworkAst;
-use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/src/bin/toutf8.rs
+++ b/src/bin/toutf8.rs
@@ -1,8 +1,9 @@
-use anyhow::Result;
-use rrdbc::encoding::to_utf8;
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
+
+use anyhow::Result;
+use rrdbc::encoding::to_utf8;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/src/bin/utf82gbk.rs
+++ b/src/bin/utf82gbk.rs
@@ -1,8 +1,9 @@
-use anyhow::Result;
-use rrdbc::encoding::utf8_to_gbk;
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
+
+use anyhow::Result;
+use rrdbc::encoding::utf8_to_gbk;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1,10 +1,11 @@
 // https://github.com/hsivonen/recode_rs
 
-use crate::error::DbcError;
-use encoding_rs::*;
-use std::io::Read;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::str::from_utf8_mut;
+
+use encoding_rs::*;
+
+use crate::error::DbcError;
 
 pub fn utf8_to_gbk(src_data: &[u8]) -> Result<Vec<u8>, DbcError> {
     recode(src_data, "UTF-8", "GBK")

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,9 +1,10 @@
-use crate::ast::network_ast::parse_dbc;
-use crate::ast::network_ast::NetworkAst;
-use crate::encoding::to_utf8;
-use anyhow::Result;
 use std::fs::File;
 use std::io::Read;
+
+use anyhow::Result;
+
+use crate::ast::network_ast::{parse_dbc, NetworkAst};
+use crate::encoding::to_utf8;
 
 pub fn read_file_content(filename: &str, encoding: &str) -> Result<String> {
     let data = if encoding.to_lowercase() == "utf-8" {

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,5 +1,6 @@
-use super::node::Node;
 use std::collections::HashMap;
+
+use super::node::Node;
 
 pub struct Network {
     /// nodes (BU)


### PR DESCRIPTION
Use `just fmt` to reformat and organize imports